### PR TITLE
fix chown data on NFS storage

### DIFF
--- a/5/alpine/docker-entrypoint.sh
+++ b/5/alpine/docker-entrypoint.sh
@@ -11,12 +11,8 @@ fi
 # allow the container to be started with `--user`
 if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of user-mutable directories to elasticsearch
-	for path in \
-		/usr/share/elasticsearch/data \
-		/usr/share/elasticsearch/logs \
-	; do
-		chown -R elasticsearch:elasticsearch "$path"
-	done
+	chown elasticsearch:elasticsearch /usr/share/elasticsearch/data; \
+	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/logs 
 	
 	set -- su-exec elasticsearch "$@"
 	#exec su-exec elasticsearch "$BASH_SOURCE" "$@"

--- a/5/docker-entrypoint.sh
+++ b/5/docker-entrypoint.sh
@@ -11,12 +11,8 @@ fi
 # allow the container to be started with `--user`
 if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	# Change the ownership of user-mutable directories to elasticsearch
-	for path in \
-		/usr/share/elasticsearch/data \
-		/usr/share/elasticsearch/logs \
-	; do
-		chown -R elasticsearch:elasticsearch "$path"
-	done
+	chown elasticsearch:elasticsearch /usr/share/elasticsearch/data; \
+	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/logs 
 	
 	set -- gosu elasticsearch "$@"
 	#exec gosu elasticsearch "$BASH_SOURCE" "$@"


### PR DESCRIPTION
When it is deployed using a volume NFS on Netapp 8080 with snapshot enabled, it failed due to .snapshot folder is read only.

docker-entrypoint-sh: chown -R on data folder return exit code != 0, and turn down elasticsearch.
Error Message: .snapshot read only file system